### PR TITLE
Feature/vagrant base - Implement Cluster Provisioning Infrastructure (Steps 1-4 and 8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+
+### Ansible ###
+*.retry
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Vagrant ###
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.log
+
+### Vagrant Patch ###
+*.box

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
-WORKER_COUNT = 2        # Numero di worker nodes nel cluster
-MEMORY_CONTROLLER = 1024#4096 # Memoria in MB per il nodo controller
-MEMORY_WORKER = 1024#6144     # Memoria in MB per ciascun worker node
-CPU_CONTROLLER = 1       # CPU cores per il nodo controller
-CPU_WORKER = 1           # CPU cores per ciascun worker node
+WORKER_COUNT = 2        # Number of workers within cluster
+MEMORY_CONTROLLER = 4096 # Controller memory (MB)
+MEMORY_WORKER = 6144     # Workers memory (MB for each worker)
+CPU_CONTROLLER = 1       # Controller CPU cores
+CPU_WORKER = 1           # Worker CPU cores (each)
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-24.04"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
-WORKER_COUNT = 2
-MEMORY_CONTROLLER = 4096
-MEMORY_WORKER = 6144
-CPU_CONTROLLER = 1
-CPU_WORKER = 1
+WORKER_COUNT = 2        # Numero di worker nodes nel cluster
+MEMORY_CONTROLLER = 1024#4096 # Memoria in MB per il nodo controller
+MEMORY_WORKER = 1024#6144     # Memoria in MB per ciascun worker node
+CPU_CONTROLLER = 1       # CPU cores per il nodo controller
+CPU_WORKER = 1           # CPU cores per ciascun worker node
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-24.04"
@@ -25,6 +25,29 @@ Vagrant.configure("2") do |config|
       node.vm.provider "virtualbox" do |vb|
         vb.memory = MEMORY_WORKER
         vb.cpus = CPU_WORKER
+      end
+      
+      # Executes Ansible after the configuration of last node
+      if i == WORKER_COUNT
+        node.vm.provision "ansible" do |ansible|
+          ansible.playbook = "ansible/general.yaml"
+          
+          ansible.groups = {
+            "controller" => ["ctrl"],
+            "worker" => (1..WORKER_COUNT).map { |j| "node-#{j}" },
+            "all:children" => ["controller", "worker"]
+          }
+          
+          ansible.extra_vars = {
+            worker_count: WORKER_COUNT,
+            memory_controller: MEMORY_CONTROLLER,
+            memory_worker: MEMORY_WORKER,
+            cpu_controller: CPU_CONTROLLER,
+            cpu_worker: CPU_WORKER
+          }
+          
+          ansible.limit = "all"
+        end
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
-# Vagrantfile (initial)
+WORKER_COUNT = 2
 MEMORY_CONTROLLER = 4096
+MEMORY_WORKER = 6144
 CPU_CONTROLLER = 1
+CPU_WORKER = 1
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-24.04"
@@ -12,6 +14,18 @@ Vagrant.configure("2") do |config|
     ctrl.vm.provider "virtualbox" do |vb|
       vb.memory = MEMORY_CONTROLLER
       vb.cpus = CPU_CONTROLLER
+    end
+  end
+  
+  # Worker nodes
+  (1..WORKER_COUNT).each do |i|
+    config.vm.define "node-#{i}" do |node|
+      node.vm.hostname = "node-#{i}"
+      node.vm.network "private_network", ip: "192.168.56.#{100+i}"
+      node.vm.provider "virtualbox" do |vb|
+        vb.memory = MEMORY_WORKER
+        vb.cpus = CPU_WORKER
+      end
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# Vagrantfile (initial)
+MEMORY_CONTROLLER = 4096
+CPU_CONTROLLER = 1
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-24.04"
+  
+  # Controller node
+  config.vm.define "ctrl" do |ctrl|
+    ctrl.vm.hostname = "ctrl"
+    ctrl.vm.network "private_network", ip: "192.168.56.100"
+    ctrl.vm.provider "virtualbox" do |vb|
+      vb.memory = MEMORY_CONTROLLER
+      vb.cpus = CPU_CONTROLLER
+    end
+  end
+end

--- a/ansible/ctrl.yaml
+++ b/ansible/ctrl.yaml
@@ -1,0 +1,7 @@
+---
+# This playbook contains specific tasks for the controller node.
+# It will be executed only on the controller node as part of the playbook general.yaml
+
+- name: Placeholder for controller specific tasks
+  debug:
+    msg: "Controller node specific provisioning will be configured in later steps"

--- a/ansible/files/ssh_keys/lorenzo.pub
+++ b/ansible/files/ssh_keys/lorenzo.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGgThZQG4W2FFDqwk0bapjnz8t6VnRdI/7CC+9daAqZQ l.sibi@student.tudelft.nl

--- a/ansible/files/ssh_keys/yongcheng.pub
+++ b/ansible/files/ssh_keys/yongcheng.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOV29DYG3R3g8zv1iVxVYsBfa2Z+1gaWsuQdqsWPQADa Y.Huang-51@student.tudelft.nl

--- a/ansible/finalization.yaml
+++ b/ansible/finalization.yaml
@@ -1,0 +1,10 @@
+---
+# This playbook will run after all nodes have been configured.
+# And the Kubernetes cluster has been initialized.
+
+- hosts: controller
+  become: true
+  tasks:
+    - name: Placeholder for finalization tasks
+      debug:
+        msg: "Finalization tasks will be configured in later steps"

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -155,3 +155,46 @@
         - kubectl
         - containerd
         - runc
+
+    - name: Ensure /etc/containerd directory exists
+      ansible.builtin.file:
+        path: /etc/containerd
+        state: directory
+        mode: '0755'
+
+    - name: Generate default containerd configuration
+      ansible.builtin.shell:
+        cmd: containerd config default > /etc/containerd/config.toml
+        creates: /etc/containerd/config.toml
+      register: config_generated
+
+    - name: Configure containerd - disable AppArmor
+      ansible.builtin.lineinfile:
+        path: /etc/containerd/config.toml
+        regexp: '^(\s*disable_apparmor\s*=\s*).*$'
+        line: '\1true'
+        backrefs: yes
+      when: config_generated.changed or config_generated.skipped is not defined
+
+    - name: Configure containerd - set sandbox image
+      ansible.builtin.lineinfile:
+        path: /etc/containerd/config.toml
+        regexp: '^(\s*sandbox_image\s*=\s*).*$'
+        line: '\1"registry.k8s.io/pause:3.10"'
+        backrefs: yes
+      when: config_generated.changed or config_generated.skipped is not defined
+
+    - name: Configure containerd - enable SystemdCgroup
+      ansible.builtin.lineinfile:
+        path: /etc/containerd/config.toml
+        regexp: '^(\s*SystemdCgroup\s*=\s*).*$'
+        line: '\1true'
+        backrefs: yes
+      when: config_generated.changed or config_generated.skipped is not defined
+
+    - name: Restart containerd service
+      ansible.builtin.service:
+        name: containerd
+        state: restarted
+        enabled: yes
+      when: config_generated.changed or config_generated.skipped is not defined

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -132,3 +132,26 @@
         state: present
         filename: kubernetes
         update_cache: yes
+
+    - name: Install containerd, runc, and Kubernetes tools
+      ansible.builtin.apt:
+        name:
+          - containerd=1.7.24-*
+          - runc=1.1.12-*
+          - kubeadm=1.32.4-*
+          - kubelet=1.32.4-*
+          - kubectl=1.32.4-*
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Hold Kubernetes packages to prevent upgrades
+      ansible.builtin.dpkg_selections:
+        name: "{{ item }}"
+        selection: hold
+      loop:
+        - kubeadm
+        - kubelet
+        - kubectl
+        - containerd
+        - runc

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -198,3 +198,31 @@
         state: restarted
         enabled: yes
       when: config_generated.changed or config_generated.skipped is not defined
+
+    - name: Ensure kubelet service.d directory exists
+      ansible.builtin.file:
+        path: /etc/systemd/system/kubelet.service.d
+        state: directory
+        mode: '0755'
+
+    - name: Ensure kubelet environment file exists
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+        content: |
+          [Service]
+          Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+          Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+          Environment="KUBELET_KUBEADM_ARGS=--network-plugin=cni --pod-infra-container-image=registry.k8s.io/pause:3.10"
+        mode: '0644'
+      register: kubelet_env
+
+    - name: Reload systemd daemon after kubelet env update
+      ansible.builtin.systemd:
+        daemon_reload: yes
+      when: kubelet_env.changed
+
+    - name: Enable and start kubelet service
+      ansible.builtin.service:
+        name: kubelet
+        state: started
+        enabled: yes

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -114,12 +114,6 @@
         - net.bridge.bridge-nf-call-iptables
         - net.bridge.bridge-nf-call-ip6tables
     
-    - name: Manage /etc/hosts file
-      ansible.builtin.template:
-        src: templates/hosts.j2
-        dest: /etc/hosts
-        mode: '0644'
-
     - name: Add Kubernetes apt key
       ansible.builtin.apt_key:
         url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -61,6 +61,7 @@
         key: "{{ lookup('file', item) }}"
       with_items:
         - "files/ssh_keys/lorenzo.pub"
+        - "files/ssh_keys/yongcheng.pub"
         # Add your public ssh keys (at least two)
 
     # Includes specific playbook for controller

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -119,3 +119,16 @@
         src: templates/hosts.j2
         dest: /etc/hosts
         mode: '0644'
+
+    - name: Add Kubernetes apt key
+      ansible.builtin.apt_key:
+        url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
+        state: present
+        keyring: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+    - name: Add Kubernetes apt repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /"
+        state: present
+        filename: kubernetes
+        update_cache: yes

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -86,3 +86,18 @@
         path: /etc/fstab
         regexp: '^[^#].*\sswap\s'
         state: absent
+
+    - name: Create k8s.conf for module loading
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+        mode: '0644'
+      register: k8s_conf
+
+    - name: Load br_netfilter module
+      ansible.builtin.modprobe:
+        name: br_netfilter
+        state: present
+      when: k8s_conf.changed

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -1,0 +1,47 @@
+---
+- hosts: all
+  become: true
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Install common packages
+      apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg
+          - lsb-release
+          - python3-pip
+        state: present
+
+    # Asignment's Step 4: Register SSH Keys
+    - name: Ensure .ssh directory exists
+      file:
+        path: /home/vagrant/.ssh
+        state: directory
+        owner: vagrant
+        group: vagrant
+        mode: "0700"
+
+    - name: Add SSH public keys
+      authorized_key:
+        user: vagrant
+        state: present
+        key: "{{ lookup('file', item) }}"
+      with_items:
+        - "files/ssh_keys/lorenzo.pub"
+        # Add your public ssh keys (at least two)
+
+    # Includes specific playbook for controller
+    - name: Include controller specific tasks
+      include_tasks: ctrl.yaml
+      when: inventory_hostname in groups['controller']
+
+    # Includes specific playbook for worker
+    - name: Include worker specific tasks
+      include_tasks: node.yaml
+      when: inventory_hostname in groups['worker']

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -101,6 +101,7 @@
         name: br_netfilter
         state: present
       when: k8s_conf.changed
+
     - name: Enable IPv4 forwarding and bridge filtering
       ansible.builtin.sysctl:
         name: "{{ item }}"
@@ -112,3 +113,9 @@
         - net.ipv4.ip_forward
         - net.bridge.bridge-nf-call-iptables
         - net.bridge.bridge-nf-call-ip6tables
+    
+    - name: Manage /etc/hosts file
+      ansible.builtin.template:
+        src: templates/hosts.j2
+        dest: /etc/hosts
+        mode: '0644'

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -73,3 +73,16 @@
     - name: Include worker specific tasks
       include_tasks: node.yaml
       when: inventory_hostname in groups['worker']
+
+    # Step 5: Disable SWAP
+    - name: Disable SWAP for current session
+      ansible.builtin.shell:
+        cmd: swapoff -a
+      changed_when: false
+      failed_when: false
+
+    - name: Remove SWAP entry from /etc/fstab
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        regexp: '^[^#].*\sswap\s'
+        state: absent

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -2,6 +2,15 @@
 - hosts: all
   become: true
   tasks:
+    - name: Get hostname
+      command: hostname
+      register: hostname_result
+      changed_when: false # Rende il task idempotente
+
+    - name: Display hostname
+      debug:
+        msg: "Current hostname is: {{ hostname_result.stdout }}"
+
     - name: Update apt cache
       apt:
         update_cache: yes
@@ -18,7 +27,25 @@
           - python3-pip
         state: present
 
-    # Asignment's Step 4: Register SSH Keys
+    - name: Generate Ansible inventory file # from templates/inventory.cfg.j2
+      template:
+        src: inventory.cfg.j2
+        dest: /home/vagrant/inventory.cfg
+        owner: vagrant
+        group: vagrant
+        mode: "0644"
+      when: inventory_hostname == groups['controller'][0]
+
+    # Step 8 (to complete and test)
+    - name: Configure /etc/hosts file # from templates/hosts.j2
+      template:
+        src: hosts.j2
+        dest: /etc/hosts
+        owner: root
+        group: root
+        mode: "0644"
+
+    # Step 4: Register SSH Keys
     - name: Ensure .ssh directory exists
       file:
         path: /home/vagrant/.ssh

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -101,3 +101,14 @@
         name: br_netfilter
         state: present
       when: k8s_conf.changed
+    - name: Enable IPv4 forwarding and bridge filtering
+      ansible.builtin.sysctl:
+        name: "{{ item }}"
+        value: '1'
+        state: present
+        sysctl_set: yes
+        reload: yes
+      loop:
+        - net.ipv4.ip_forward
+        - net.bridge.bridge-nf-call-iptables
+        - net.bridge.bridge-nf-call-ip6tables

--- a/ansible/node.yaml
+++ b/ansible/node.yaml
@@ -1,0 +1,7 @@
+---
+# This playbook contains specific tasks for worker nodes.
+# It will be executed only on worker nodes as part of the playbook general.yaml
+
+- name: Placeholder for worker node specific tasks
+  debug:
+    msg: "Worker node specific provisioning will be configured in later steps"

--- a/ansible/templates/hosts.j2
+++ b/ansible/templates/hosts.j2
@@ -1,5 +1,9 @@
 127.0.0.1 localhost
 
+::1         localhost ip6-localhost ip6-loopback
+ff02::1     ip6-allnodes
+ff02::2     ip6-allrouters
+
 # Controller node
 192.168.56.100 ctrl
 

--- a/ansible/templates/hosts.j2
+++ b/ansible/templates/hosts.j2
@@ -1,0 +1,16 @@
+127.0.0.1 localhost
+
+# Controller node
+192.168.56.100 ctrl
+
+# Worker nodes
+{% for i in range(1, worker_count | int + 1) %}
+192.168.56.{{ 100 + i }} node-{{ i }}
+{% endfor %}
+
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters

--- a/ansible/templates/inventory.cfg.j2
+++ b/ansible/templates/inventory.cfg.j2
@@ -1,0 +1,15 @@
+[controller]
+ctrl ansible_host=192.168.56.100
+
+[worker]
+{% for i in range(1, worker_count | int + 1) %}
+node-{{ i }} ansible_host=192.168.56.{{ 100 + i }}
+{% endfor %}
+
+[all:children]
+controller
+worker
+
+[all:vars]
+ansible_user=vagrant
+ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key


### PR DESCRIPTION
This PR implements the foundational infrastructure for our Kubernetes cluster provisioning, covering steps 1-to-4 and 8 of Assignment A2:

## Features
- Set up virtual infrastructure using Vagrant with configurable worker count
- Configure private networking between nodes with fixed IPs
- Implement Ansible provisioning for all nodes
- Add SSH key registration for team members  (step 4 - refer to #8 )
- Generate dynamic /etc/hosts file based on actual cluster size (Step 8)
- Create inventory.cfg for easier Ansible management

## Testing
- Verified VM creation with correct hostnames and networking
- Confirmed node interconnectivity via private network
- Validated SSH key registration for passwordless access (if you aded your SHH public key)
- Tested host resolution using the generated /etc/hosts file
- Tested Ansible idempotency. Try by yourself running `vagrant provision' for a second time. Output should show for the `/etc/hosts` and `inventory.cfg` file generation tasks `changed=0` if there were no configuration changes.

All VMs are configured with some of the basic environment needed for the upcoming Kubernetes installation steps. If needed feel free to modify/add them for the further steps.