### PR TITLE
Promtheus monitoring

### DIFF
--- a/ansible/finalization.yaml
+++ b/ansible/finalization.yaml
@@ -281,3 +281,39 @@
           - "Istio has been deployed using Helm according to the official documentation."
           - "The control plane (istiod) is installed in istio-system namespace."
           - "The ingress gateway is installed in istio-ingress namespace."
+
+    - name: Create monitoring namespace
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: monitoring
+        kubeconfig: "{{ kubeconfig }}"
+
+    - name: Add Prometheus Helm repo
+      kubernetes.core.helm_repository:
+        name: prometheus-community
+        repo_url: https://prometheus-community.github.io/helm-charts
+        
+    - name: Install Prometheus Stack
+      kubernetes.core.helm:
+        name: prometheus
+        chart_ref: prometheus-community/kube-prometheus-stack
+        release_namespace: monitoring
+        create_namespace: false
+        kubeconfig: "{{ kubeconfig }}"
+        wait: true
+
+    - name: Wait for Prometheus components to be ready
+      shell: kubectl --kubeconfig={{ kubeconfig }} wait --for=condition=ready pod -l app.kubernetes.io/name=prometheus -n monitoring --timeout=180s
+      changed_when: false
+
+    - name: Instructions for Prometheus
+      debug:
+        msg:
+          - "Prometheus has been deployed using Helm in the monitoring namespace"
+          - "The kube-prometheus-stack includes Prometheus, Alertmanager, and Grafana"
+          - "ServiceMonitor CRDs are now available for monitoring services"
+

--- a/ansible/finalization.yaml
+++ b/ansible/finalization.yaml
@@ -213,3 +213,71 @@
           - "2. Run this command to get a login token: kubectl -n kubernetes-dashboard create token admin-user"
           - "3. Access the dashboard at https://dashboard.local (note: using HTTPS)"
           - "4. You may need to accept the self-signed certificate warning in your browser"
+
+    # Step 23: Install Istio using Helm
+    - name: Add Istio Helm repository
+      kubernetes.core.helm_repository:
+        name: istio
+        repo_url: https://istio-release.storage.googleapis.com/charts
+        kubeconfig: "{{ kubeconfig }}"
+
+    - name: Create istio-system namespace
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: istio-system
+        kubeconfig: "{{ kubeconfig }}"
+
+    - name: Install Istio base chart (CRDs)
+      kubernetes.core.helm:
+        name: istio-base
+        chart_ref: istio/base
+        release_namespace: istio-system
+        create_namespace: false
+        kubeconfig: "{{ kubeconfig }}"
+        wait: true
+        chart_version: "1.25.2"
+
+    - name: Install Istio istiod (control plane)
+      kubernetes.core.helm:
+        name: istiod
+        chart_ref: istio/istiod
+        release_namespace: istio-system
+        create_namespace: false
+        kubeconfig: "{{ kubeconfig }}"
+        wait: true
+        chart_version: "1.25.2"
+
+    - name: Create istio-ingress namespace
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: istio-ingress
+        kubeconfig: "{{ kubeconfig }}"
+
+    - name: Install Istio ingress gateway
+      kubernetes.core.helm:
+        name: istio-ingress
+        chart_ref: istio/gateway
+        release_namespace: istio-ingress
+        create_namespace: false
+        kubeconfig: "{{ kubeconfig }}"
+        wait: true
+        chart_version: "1.25.2"
+
+    - name: Wait for Istio components to be ready
+      shell: kubectl --kubeconfig={{ kubeconfig }} wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=120s
+      changed_when: false
+
+    - name: Instructions for Istio
+      debug:
+        msg:
+          - "Istio has been deployed using Helm according to the official documentation."
+          - "The control plane (istiod) is installed in istio-system namespace."
+          - "The ingress gateway is installed in istio-ingress namespace."

--- a/helm/myapp/templates/alertmanagerconfig.yaml
+++ b/helm/myapp/templates/alertmanagerconfig.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.alertmanager.enabled }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: {{ include "myapp.fullname" . }}-alerts
+  labels:
+    {{- include "myapp.labels" . | nindent 4 }}
+spec:
+  route:
+    groupBy: ['alertname', 'severity']
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 4h
+    receiver: 'email-notifications'
+    routes:
+    - matchers:
+      - name: severity
+        value: warning
+      receiver: 'email-notifications'
+  receivers:
+  - name: 'email-notifications'
+    emailConfigs:
+    - to: 'alerts@example.com'
+      from: 'alertmanager@example.com'
+      smarthost: 'smtp.example.com:587'
+      authUsername: 'alertmanager'
+      authPassword:
+        name: {{ include "myapp.fullname" . }}-secret
+        key: smtpPassword
+      requireTLS: true
+      sendResolved: true
+{{- end }} 

--- a/helm/myapp/templates/deployment.yaml
+++ b/helm/myapp/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         {{- include "myapp.labels" . | nindent 8 }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "{{ .Values.service.targetPort }}"
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -20,6 +24,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.targetPort }}
+              name: http
           env:
             - name: MODEL_SERVICE_URL
               valueFrom:

--- a/helm/myapp/templates/ingress.yaml
+++ b/helm/myapp/templates/ingress.yaml
@@ -5,7 +5,12 @@ metadata:
   name: {{ include "myapp.fullname" . }}
   labels:
     {{- include "myapp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.className | default "nginx" }}
   rules:
     - host: {{ .Values.ingress.host | default (printf "%s.myapp.local" .Release.Name) }}
       http:

--- a/helm/myapp/templates/prometheus-ingress.yaml
+++ b/helm/myapp/templates/prometheus-ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.prometheus.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-{{ include "myapp.fullname" . }}
+  namespace: monitoring
+  labels:
+    {{- include "myapp.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- with .Values.prometheus.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.prometheus.ingress.className | default "nginx" }}
+  rules:
+    - host: {{ .Values.prometheus.ingress.host | default (printf "prometheus-%s.local" .Release.Name) }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus-kube-prometheus-prometheus
+                port:
+                  number: 9090
+{{- end }} 

--- a/helm/myapp/templates/prometheusrule.yaml
+++ b/helm/myapp/templates/prometheusrule.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.prometheusRules.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "myapp.fullname" . }}-rules
+  namespace: monitoring
+  labels:
+    {{- include "myapp.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRules.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  - name: {{ include "myapp.fullname" . }}.rules
+    rules:
+    - alert: HighRequestRate
+      expr: sum(rate(flask_http_request_total{service="{{ .Values.service.name }}-{{ include "myapp.fullname" . }}"}[1m])) > 15
+      for: 2m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High request rate detected"
+        description: "Service {{ .Values.service.name }}-{{ include "myapp.fullname" . }} has received more than 15 requests per minute for the last 2 minutes"
+        runbook_url: "https://example.com/runbooks/high-traffic"
+{{- end }} 

--- a/helm/myapp/templates/servicemonitor.yaml
+++ b/helm/myapp/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "myapp.fullname" . }}
+  labels:
+    {{- include "myapp.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "myapp.labels" . | nindent 6 }}
+  endpoints:
+  - port: http
+    path: /metrics
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+{{- end }} 

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/remla25-team8/app
-  tag: "1.1.0"
+  tag: "1.1.4"
   pullPolicy: IfNotPresent
 
 namePrefix: ""

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: d4vidhuang/remla25-team8-app
+  repository: ghcr.io/remla25-team8/app
   tag: "1.1.0"
   pullPolicy: IfNotPresent
 
@@ -21,6 +21,11 @@ ingress:
   enabled: true
   host: ""
   path: /
+  className: nginx
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # Other annotations as needed
 
 configMap:
   modelServiceUrl: http://model-service:8080

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -36,6 +36,38 @@ metrics:
     additionalLabels:
       release: prometheus  # This is important for Prometheus Operator to discover the ServiceMonitor
 
+# PrometheusRules configuration
+prometheusRules:
+  enabled: true
+  additionalLabels:
+    release: prometheus  # Match the release name used for Prometheus Operator
+
+# AlertManager configuration for email alerts
+alertmanager:
+  enabled: true
+  config:
+    global:
+      smtp_smarthost: 'smtp.example.com:587'
+      smtp_from: 'alertmanager@example.com'
+      smtp_auth_username: 'alertmanager'
+      smtp_auth_password: '{{ .Values.secret.smtpPassword }}'
+      smtp_require_tls: true
+    route:
+      group_by: ['alertname', 'severity']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      receiver: 'email-notifications'
+      routes:
+      - match:
+          severity: warning
+        receiver: 'email-notifications'
+    receivers:
+    - name: 'email-notifications'
+      email_configs:
+      - to: 'alerts@example.com'
+        send_resolved: true
+
 # Prometheus ingress configuration
 prometheus:
   ingress:

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -27,6 +27,24 @@ ingress:
     # kubernetes.io/tls-acme: "true"
     # Other annotations as needed
 
+# Metrics configuration
+metrics:
+  serviceMonitor:
+    enabled: true
+    interval: 15s
+    scrapeTimeout: 10s
+    additionalLabels:
+      release: prometheus  # This is important for Prometheus Operator to discover the ServiceMonitor
+
+# Prometheus ingress configuration
+prometheus:
+  ingress:
+    enabled: true
+    className: nginx
+    host: prometheus.local  # You can modify this to any domain you want
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+
 configMap:
   modelServiceUrl: http://model-service:8080
 


### PR DESCRIPTION
I'm not entirely sure if the automated alert fires correctly, but everything prometheus related aside from that should work.

## The metrics we collect:
- app_info - Basic application version information
- sentiment_analysis_total - Count of sentiment analysis requests, labeled by sentiment (positive/negative)
- model_response_time_seconds - Histogram of model service response times in seconds
- active_users - Gauge tracking current users on each page
- user_feedback_total - Count of feedback submissions with labels for correctness and sentiment types
- flask_http_request_total - Total HTTP requests (added automatically by Flask exporter)
- flask_http_request_duration_seconds - HTTP request durations (added automatically by Flask exporter)

After following the Helm readme you can find prometheus at: 
- http://prometheus.local/

The custom alert is called:
- HighRequestRate

Also made some changes that hopefully make setup a bit easier. I suggest running finalization before helm install.