### PR TITLE
Canary Release works for AB testing setup, also added shadow release

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,37 +102,35 @@ This will allow you to access the various web interfaces by hostname.
 3. Inside the VM (ctrl), deploy the app:
     ```bash
       cd /vagrant/helm/myapp
-
-      # Create the required secret (required only the first time)
-      Create the Secret for sensitive data:
+   ```
+      Create the required secret (required only the first time):
       ```sh
       kubectl create secret generic dev-myapp-secret --from-literal=smtpPassword=<your-SMTP-password>
       ```
 
       Install the chart:
       ```sh
-      helm install dev-myapp . --set namePrefix=dev --set ingress.host=dev.myapp.local
+      helm install dev-myapp . --set namePrefix=dev 
       ```
-
-      Ensure ingress is running:
+      Test Istio:
       ```bash
-      kubectl get pods -n ingress-nginx  # Should show Running status   
+         bash tests/sticky-session-test.sh
       ```
+      
 
 5. Outside the VMs, on your host machine:
 
       Add to `/etc/hosts` file the following:
 
          - 192.168.56.90 grafana.myapp.local
-         - 192.168.56.90 dev.myapp.local
+         - 192.168.56.91 app.local
          - 192.168.56.90 prometheus.local
-   
 
 ### Accessing the Application
 
 After deployment, you can access the following services:
 
-* Web Application: http://dev.myapp.local
+* Web Application: http://app.local
 * Kubernetes Dashboard: https://dashboard.local (setup instructions during provisioning also requires adding to hosts file)
 * Grafana: http://grafana.myapp.local (credentials: admin/prom-operator)
 * Prometheus: http://prometheus.local

--- a/helm/myapp/templates/_helpers.tpl
+++ b/helm/myapp/templates/_helpers.tpl
@@ -35,7 +35,6 @@ Common labels
 */}}
 {{- define "myapp.labels" -}}
 helm.sh/chart: {{ include "myapp.chart" . }}
-{{ include "myapp.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,11 +45,21 @@ app.kubernetes.io/prefix: {{ .Values.namePrefix }}
 {{- end }}
 
 {{/*
-Selector labels
+App-specific selector labels
 */}}
-{{- define "myapp.selectorLabels" -}}
+{{- define "myapp.appSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "myapp.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+component: app
+{{- end }}
+
+{{/*
+Model service-specific selector labels
+*/}}
+{{- define "myapp.modelSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "myapp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+component: model-service
 {{- end }}
 
 {{/*

--- a/helm/myapp/templates/configmap.yaml
+++ b/helm/myapp/templates/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     {{- include "myapp.labels" . | nindent 4 }}
 data:
-  modelServiceUrl: {{ .Values.configMap.modelServiceUrl }}
+  modelServiceUrl: http://{{ if .Values.namePrefix }}{{ .Values.namePrefix }}-{{ .Values.modelService.name }}{{ else }}{{ .Values.modelService.name }}{{ end }}:{{ .Values.modelService.port }}

--- a/helm/myapp/templates/deployment.yaml
+++ b/helm/myapp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-# v1 Deployment
+# v1 App Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,27 +45,31 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 ---
+# v1 Model Service Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.namePrefix }}-model-service
+  name: {{ .Values.namePrefix }}-model-service-v1
   labels:
     {{- include "myapp.labels" . | nindent 4 }}
     app: model-service
+    version: v1
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: model-service
+      version: v1
       {{- include "myapp.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         app: model-service
+        version: v1
         {{- include "myapp.labels" . | nindent 8 }}
     spec:
       containers:
-        - name: model-service
+        - name: model-service-v1
           image: "{{ .Values.modelImage.repository }}:{{ .Values.modelImage.tag }}"
           imagePullPolicy: {{ .Values.modelImage.pullPolicy }}
           ports:
@@ -79,7 +83,7 @@ spec:
               cpu: "500m"
               memory: "512Mi"
 ---
-# v2 Deployment
+# v2 App Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -107,8 +111,8 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}" # TODO: change to the correct image later when we have an
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.appImageV2.repository }}:{{ .Values.appImageV2.tag }}"
+          imagePullPolicy: {{ .Values.appImageV2.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.targetPort }}
               name: http
@@ -125,3 +129,41 @@ spec:
                   key: smtpPassword
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+---
+# v2 Model Service Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.namePrefix }}-model-service-v2
+  labels:
+    {{- include "myapp.labels" . | nindent 4 }}
+    app: model-service
+    version: v2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model-service
+      version: v2
+      {{- include "myapp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app: model-service
+        version: v2
+        {{- include "myapp.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: model-service-v2
+          image: "{{ .Values.modelImageV2.repository }}:{{ .Values.modelImageV2.tag }}"
+          imagePullPolicy: {{ .Values.modelImageV2.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.modelService.targetPort }}
+              name: http
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/helm/myapp/templates/deployment.yaml
+++ b/helm/myapp/templates/deployment.yaml
@@ -10,15 +10,12 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "myapp.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "myapp.appSelectorLabels" . | nindent 6 }}
       version: v1
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "myapp.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app: myapp
+        {{- include "myapp.appSelectorLabels" . | nindent 8 }}
         version: v1
       annotations:
         prometheus.io/scrape: "true"
@@ -59,15 +56,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: model-service
+      {{- include "myapp.modelSelectorLabels" . | nindent 6 }}
       version: v1
-      {{- include "myapp.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: model-service
+        {{- include "myapp.modelSelectorLabels" . | nindent 8 }}
         version: v1
-        {{- include "myapp.labels" . | nindent 8 }}
     spec:
       containers:
         - name: model-service-v1
@@ -96,15 +91,12 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "myapp.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "myapp.appSelectorLabels" . | nindent 6 }}
       version: v2
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "myapp.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app: myapp
+        {{- include "myapp.appSelectorLabels" . | nindent 8 }}
         version: v2
       annotations:
         prometheus.io/scrape: "true"
@@ -145,15 +137,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: model-service
+      {{- include "myapp.modelSelectorLabels" . | nindent 6 }}
       version: v2
-      {{- include "myapp.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: model-service
+        {{- include "myapp.modelSelectorLabels" . | nindent 8 }}
         version: v2
-        {{- include "myapp.labels" . | nindent 8 }}
     spec:
       containers:
         - name: model-service-v2
@@ -169,3 +159,41 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+{{- if .Values.shadowLaunch.enabled }}
+---
+# Shadow Model Service Deployment (for testing with traffic mirroring)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.namePrefix }}-model-service-shadow
+  labels:
+    {{- include "myapp.labels" . | nindent 4 }}
+    app: model-service
+    version: shadow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "myapp.modelSelectorLabels" . | nindent 6 }}
+      version: shadow
+  template:
+    metadata:
+      labels:
+        {{- include "myapp.modelSelectorLabels" . | nindent 8 }}
+        version: shadow
+    spec:
+      containers:
+        - name: model-service-shadow
+          image: "{{ .Values.shadowLaunch.image.repository }}:{{ .Values.shadowLaunch.image.tag }}"
+          imagePullPolicy: {{ .Values.shadowLaunch.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.modelService.targetPort }}
+              name: http
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+{{- end }}

--- a/helm/myapp/templates/deployment.yaml
+++ b/helm/myapp/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app: myapp
         version: v1
       annotations:
         prometheus.io/scrape: "true"
@@ -103,6 +104,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "myapp.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app: myapp
         version: v2
       annotations:
         prometheus.io/scrape: "true"

--- a/helm/myapp/templates/destinationrule.yaml
+++ b/helm/myapp/templates/destinationrule.yaml
@@ -13,4 +13,20 @@ spec:
   - name: v2
     labels:
       version: v2
+---
+# DestinationRule for model service internal routing
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: {{ include "myapp.fullname" . }}-model-dr
+  namespace: default
+spec:
+  host: {{ .Values.namePrefix }}-{{ .Values.modelService.name }}
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
 {{- end }}

--- a/helm/myapp/templates/destinationrule.yaml
+++ b/helm/myapp/templates/destinationrule.yaml
@@ -29,4 +29,9 @@ spec:
   - name: v2
     labels:
       version: v2
+{{- if .Values.shadowLaunch.enabled }}
+  - name: shadow
+    labels:
+      version: shadow
+{{- end }}
 {{- end }}

--- a/helm/myapp/templates/destinationrule.yaml
+++ b/helm/myapp/templates/destinationrule.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "myapp.fullname" . }}
   namespace: default
 spec:
-  host: {{ .Values.service.name }}-{{ include "myapp.fullname" . }}
+  host: {{ .Values.namePrefix }}-{{ .Values.service.name }}
   subsets:
   - name: v1
     labels:

--- a/helm/myapp/templates/service.yaml
+++ b/helm/myapp/templates/service.yaml
@@ -14,6 +14,7 @@ spec:
   selector:
     {{- include "myapp.selectorLabels" . | nindent 4 }}
 ---
+# Model Service (routes to both v1 and v2 model pods)
 apiVersion: v1
 kind: Service
 metadata:
@@ -28,4 +29,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: model-service
+    app: model-service  # Selects both v1 and v2 model pods

--- a/helm/myapp/templates/service.yaml
+++ b/helm/myapp/templates/service.yaml
@@ -12,6 +12,7 @@ spec:
       protocol: TCP
       name: http
   selector:
+    app: myapp
     {{- include "myapp.selectorLabels" . | nindent 4 }}
 ---
 # Model Service (routes to both v1 and v2 model pods)

--- a/helm/myapp/templates/service.yaml
+++ b/helm/myapp/templates/service.yaml
@@ -12,8 +12,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: myapp
-    {{- include "myapp.selectorLabels" . | nindent 4 }}
+    {{- include "myapp.appSelectorLabels" . | nindent 4 }}
 ---
 # Model Service (routes to both v1 and v2 model pods)
 apiVersion: v1
@@ -30,4 +29,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: model-service  # Selects both v1 and v2 model pods
+    {{- include "myapp.modelSelectorLabels" . | nindent 4 }}

--- a/helm/myapp/templates/virtualservice.yaml
+++ b/helm/myapp/templates/virtualservice.yaml
@@ -45,8 +45,22 @@ spec:
     - destination:
         host: {{ .Values.namePrefix }}-{{ .Values.modelService.name }}
         subset: v2
+{{- if .Values.shadowLaunch.enabled }}
+    mirror:
+      host: {{ .Values.namePrefix }}-{{ .Values.modelService.name }}
+      subset: shadow
+    mirrorPercentage:
+      value: {{ .Values.shadowLaunch.mirrorPercentage | default 100.0 }}
+{{- end }}
   - route: # default route for v1 and any other traffic
     - destination:
         host: {{ .Values.namePrefix }}-{{ .Values.modelService.name }}
         subset: v1
+{{- if .Values.shadowLaunch.enabled }}
+    mirror:
+      host: {{ .Values.namePrefix }}-{{ .Values.modelService.name }}
+      subset: shadow
+    mirrorPercentage:
+      value: {{ .Values.shadowLaunch.mirrorPercentage | default 100.0 }}
+{{- end }}
 {{- end }}

--- a/helm/myapp/templates/virtualservice.yaml
+++ b/helm/myapp/templates/virtualservice.yaml
@@ -27,4 +27,26 @@ spec:
         host: {{ .Values.service.name }}-{{ include "myapp.fullname" . }}
         subset: v2
       weight: 10
+---
+# Internal VirtualService for model-service routing based on source app version
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ include "myapp.fullname" . }}-model-vs
+  namespace: default
+spec:
+  hosts:
+  - {{ .Values.namePrefix }}-{{ .Values.modelService.name }}
+  http:
+  - match:
+    - sourceLabels:
+        version: v2
+    route:
+    - destination:
+        host: {{ .Values.namePrefix }}-{{ .Values.modelService.name }}
+        subset: v2
+  - route: # default route for v1 and any other traffic
+    - destination:
+        host: {{ .Values.namePrefix }}-{{ .Values.modelService.name }}
+        subset: v1
 {{- end }}

--- a/helm/myapp/templates/virtualservice.yaml
+++ b/helm/myapp/templates/virtualservice.yaml
@@ -16,15 +16,15 @@ spec:
           exact: "{{ .Values.istio.sticky.userId }}"
     route:
     - destination:
-        host: {{ .Values.service.name }}-{{ include "myapp.fullname" . }}
+        host: {{ .Values.namePrefix }}-{{ .Values.service.name }}
         subset: v2
   - route:
     - destination:
-        host: {{ .Values.service.name }}-{{ include "myapp.fullname" . }}
+        host: {{ .Values.namePrefix }}-{{ .Values.service.name }}
         subset: v1
       weight: 90
     - destination:
-        host: {{ .Values.service.name }}-{{ include "myapp.fullname" . }}
+        host: {{ .Values.namePrefix }}-{{ .Values.service.name }}
         subset: v2
       weight: 10
 ---

--- a/helm/myapp/tests/sticky-session-test.sh
+++ b/helm/myapp/tests/sticky-session-test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
      echo "Testing default routing (90% v1, 10% v2)"
      for i in {1..10}; do
-       curl -H "Host: app.local" http://192.168.56.91/predict -d '{"text": "Great food!"}' -H "Content-Type: application/json"
+       curl -H "Host: app.local" http://192.168.56.91/analyze -d '{"review": "Great food!"}' -H "Content-Type: application/json"
      done
 
      echo "Testing Sticky Session with x-user-id=test-user (always v2)"
      for i in {1..5}; do
-       curl -H "Host: app.local" -H "x-user-id: test-user" http://192.168.56.91/predict -d '{"text": "Great food!"}' -H "Content-Type: application/json"
+       curl -H "Host: app.local" -H "x-user-id: test-user" http://192.168.56.91/analyze -d '{"review": "Great food!"}' -H "Content-Type: application/json"
      done

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -8,7 +8,7 @@ appImage:
 # Configuration for v2 app deployment
 appImageV2:
   repository: ghcr.io/remla25-team8/app
-  tag: "2.0.0"  # Set this to your v2 app version
+  tag: "1.1.4"  # Set this to your v2 app version
   pullPolicy: IfNotPresent
 
 modelImage:
@@ -19,7 +19,7 @@ modelImage:
 # V2 Model Service configuration
 modelImageV2:
   repository: ghcr.io/remla25-team8/model-service
-  tag: "2.0.0"  # Different model version for v2
+  tag: "1.0.0"  # Different model version for v2
   pullPolicy: IfNotPresent
 
 namePrefix: ""

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -5,9 +5,21 @@ appImage:
   tag: "1.1.4"
   pullPolicy: IfNotPresent
 
+# Configuration for v2 app deployment
+appImageV2:
+  repository: ghcr.io/remla25-team8/app
+  tag: "2.0.0"  # Set this to your v2 app version
+  pullPolicy: IfNotPresent
+
 modelImage:
   repository: ghcr.io/remla25-team8/model-service
   tag: "1.0.0"
+  pullPolicy: IfNotPresent
+
+# V2 Model Service configuration
+modelImageV2:
+  repository: ghcr.io/remla25-team8/model-service
+  tag: "2.0.0"  # Different model version for v2
   pullPolicy: IfNotPresent
 
 namePrefix: ""
@@ -26,7 +38,7 @@ modelService:
   name: model-service
   port: 5000
   targetPort: 5000
-  type: ClusterIP
+  type: ClusterIP  # Internal only - not exposed externally
 
 ingress:
   enabled: false

--- a/helm/myapp/values.yaml
+++ b/helm/myapp/values.yaml
@@ -8,7 +8,7 @@ appImage:
 # Configuration for v2 app deployment
 appImageV2:
   repository: ghcr.io/remla25-team8/app
-  tag: "1.1.4"  # Set this to your v2 app version
+  tag: "1.1.4"  # TODO: change to v2 version
   pullPolicy: IfNotPresent
 
 modelImage:
@@ -19,7 +19,7 @@ modelImage:
 # V2 Model Service configuration
 modelImageV2:
   repository: ghcr.io/remla25-team8/model-service
-  tag: "1.0.0"  # Different model version for v2
+  tag: "1.0.0"  # TODO: change to v2 version
   pullPolicy: IfNotPresent
 
 namePrefix: ""
@@ -146,3 +146,12 @@ resources: {}
   # requests:
   #   cpu: 200m
   #   memory: 256Mi
+
+# Shadow Launch Configuration (Traffic Mirroring for Testing)
+shadowLaunch:
+  enabled: false  # Set to true to enable shadow testing
+  mirrorPercentage: 100.0  # Percentage of traffic to mirror (0-100)
+  image:
+    repository: ghcr.io/remla25-team8/model-service
+    tag: "1.0.0"  #TODO: change to shadow version
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Updated README since now app is on app.local. Also currently all versions and shadow release use the same image. We should make a couple of different images for model-service and app going forward.